### PR TITLE
Add 'idx' & 'rootNodeClass'

### DIFF
--- a/src/VirtualScroll.svelte
+++ b/src/VirtualScroll.svelte
@@ -51,6 +51,11 @@
      * @type {number}
      */
     export let bottomThreshold = 0
+    /**
+     * Class to assign to virtual scroll root node.
+     * @type {string}
+     */
+    export let rootNodeClass = ''
 
     let displayItems = []
     let paddingStyle
@@ -261,20 +266,20 @@
     }
 </script>
 
-<div bind:this={root} on:scroll={onScroll} style="overflow-y: auto; height: inherit">
+<div bind:this={root} on:scroll={onScroll} class={rootNodeClass} style="overflow-y: auto; height: inherit">
     {#if $$slots.header}
         <Item on:resize={onItemResized} type="slot" uniqueKey="header">
             <slot name="header"/>
         </Item>
     {/if}
     <div style="padding: {paddingStyle}">
-        {#each displayItems as data (data[key])}
+        {#each displayItems as data, idx (data[key])}
             <Item
                     on:resize={onItemResized}
                     uniqueKey={data[key]}
                     horizontal={isHorizontal}
                     type="item">
-                <slot {data}/>
+                <slot {data} {idx}/>
             </Item>
         {/each}
     </div>

--- a/types/VirtualScroll.d.ts
+++ b/types/VirtualScroll.d.ts
@@ -62,6 +62,12 @@ export interface VirtualScrollProps<T> {
   bottomThreshold?: number;
 
   /**
+   * Class to assign to virtual scroll root node.
+   * @type {string}
+   */
+  rootNodeClass?: string;
+
+  /**
    * @default () => { return virtual.sizes.get(id) }
    */
   getSize?: () => any;
@@ -111,5 +117,5 @@ export interface VirtualScrollProps<T> {
 export default class VirtualScroll<T> extends SvelteComponentTyped<
   VirtualScrollProps<T>,
   { scroll: CustomEvent<any>; top: CustomEvent<any>; bottom: CustomEvent<any> },
-  { default: { data: T }; footer: {}; header: {} }
+  { default: { data: T, idx: number }; footer: {}; header: {} }
 > {}


### PR DESCRIPTION
The 'idx' property exposes to the slot idx of the element.
The 'rootNodeClass' property enables manipulation of the top virtual scroll node in case it needs to be modified.